### PR TITLE
Fix missing tunnels_ dictionary initialisation

### DIFF
--- a/src/ios/CDVNabto.m
+++ b/src/ios/CDVNabto.m
@@ -56,6 +56,7 @@
 }
 
 - (void)startupAndOpenProfile:(CDVInvokedUrlCommand*)command {
+    tunnels_ = [NSMutableDictionary dictionary];
     [self.commandDelegate runInBackground:^{
         CDVPluginResult* res = nil;
 


### PR DESCRIPTION
Hello, 

we've been testing this library to display p2p data from an IoT device. It all works fine and we were able to get live data on a mobile device using `tunnels` and `rpc-websocket`. 

I noticed we always got an error on iOs while on Android it worked totally fine - the error was generic so it took a while to figure out. Turns out if we use `startupAndOpenProfile`, the `tunnels_` dictionary is not initialized, so all the tunnels opened do not get saved into `tunnels_`, making all the subsequent calls (e.g. getting the tunnel port) fail with an "INVALID_TUNNEL" error.

This adds the missing initialization (Not sure if this is covered with tests, but I'm not an obj-c developer so that's all I could do to fix this issue 😅)